### PR TITLE
Add contributing documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# Notes for developers
+
+Please read this before hacking on/contributing to `unicop`.
+
+
+## Run tests
+
+The directory [`example-files/`](example-files/) contain files for various programming languages and with various
+"bad" unicode in them. These can be used to test out `unicop` while developing.
+
+Automatic tests also run against these to verify the output of `unicop` stays consistent, and the correct
+issues are raised.
+
+## Git commit style
+
+Please follow the guidelines at https://cbea.ms/git-commit/ for git commit message style. There is a CI
+job that will enforce this.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ $ unicop example-files/homoglyph.js example-files/invisible.js
 
 ```
 
+## Contributing to unicop
+
+Please see the [contribution](CONTRIBUTING.md) documentation for details on how to understand, build and test
+this program, as well as submitting changes.
+
 ## Todo
 
 Things left to implement to make this usable


### PR DESCRIPTION
I don't expect lots of external contribution. But I wanted somewhere to write stuff about how the program works. Mostly for ourselves. And I don't think notes to developers belong in the main readme. The main readme should be for users of the program. So I split it up like this.

Everything should still be reachable from the main readme however. I think it's important that it links to all other docs and things worth knowing.