### PR TITLE
Add `--print-characters` command

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,12 +52,8 @@ impl FromStr for CharacterType {
 }
 
 fn unicode_notation_to_char(unicode_notation: &str) -> Result<char, InvalidCharacterType> {
-    let parse = |unicode_notation: &str| -> Option<char> {
-        let hex_str_number = unicode_notation.strip_prefix("U+")?;
-        let int_number = u32::from_str_radix(hex_str_number, 16).ok()?;
-        char::from_u32(int_number)
-    };
-    parse(unicode_notation).ok_or_else(|| InvalidCharacterType(unicode_notation.to_owned()))
+    crate::unicode_notation::unicode_notation_to_char(unicode_notation)
+        .ok_or_else(|| InvalidCharacterType(unicode_notation.to_owned()))
 }
 
 /// All types of code that can have special rules about what is allowed or denied.

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -46,7 +46,7 @@ impl RuleSet {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CharacterType {
     /// Single character (eg. "U+9000")
     CodePoint(char),

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,6 +1,6 @@
 /// List of bidirectional formatting characters from <https://en.wikipedia.org/wiki/Trojan_Source>
-const BIDI_CHARACTERS: &[char] = &[
-    '\u{202A}', '\u{202b}', '\u{202c}', '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}',
+pub const BIDI_CHARACTERS: &[char] = &[
+    '\u{202A}', '\u{202B}', '\u{202C}', '\u{202D}', '\u{202E}', '\u{2066}', '\u{2067}', '\u{2068}',
     '\u{2069}',
 ];
 

--- a/src/unicode_notation.rs
+++ b/src/unicode_notation.rs
@@ -1,0 +1,9 @@
+pub fn unicode_notation_to_char(unicode_notation: &str) -> Option<char> {
+    let hex_str_number = unicode_notation.strip_prefix("U+")?;
+    let int_number = u32::from_str_radix(hex_str_number, 16).ok()?;
+    char::from_u32(int_number)
+}
+
+pub fn char_to_unicode_notation(c: char) -> String {
+    format!("U+{:X}", u32::from(c))
+}


### PR DESCRIPTION
This command takes anything that parses into a `CharacterType` as argument. This helps the user discover the Unicode space.

Also fixes a bug in `--print-unicode-block`. Previously it printed the decimal integer value for the block range ends. Now it properly prints it in uppercase hex, just like how we parse it.