### PR TITLE
Allow "ascii" as shorthand for the unicode block "Basic Latin"

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -29,6 +29,10 @@ impl FromStr for CharacterType {
     type Err = InvalidCharacterType;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        // Shorthand to the ascii unicode block
+        if s == "ascii" {
+            return Ok(Self::Block(&crate::unicode_blocks::BASIC_LATIN));
+        }
         if s == "bidi" {
             return Ok(Self::Bidi);
         }


### PR DESCRIPTION
Since allowing ASCII will be very common (even part of the default config) it should be simple to refer to.

Our readme example config even uses it. This example config is not even valid before this PR :see_no_evil: 