### PR TITLE
Use `char::MIN` and `char::MAX` instead of hardcoded constants

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
         # TODO: Add and make Windows work in CI also
         os: [ubuntu-latest, macos-latest]
         # Keep MSRV in sync with rust-version in Cargo.toml
-        rust: [stable, beta, nightly, 1.79.0]
+        rust: [stable, beta, nightly, 1.83.0]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/mullvad/unicop"
 license = "GPL-3.0"
 
 edition = "2021"
-rust-version = "1.79.0"
+rust-version = "1.83.0"
 
 [dependencies]
 miette = { version = "7.2.0", features = ["fancy"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,9 +158,7 @@ fn main() -> anyhow::Result<()> {
             CharacterType::Range(range) => print_char_range(range),
             CharacterType::Bidi => print_char_range(rules::BIDI_CHARACTERS.iter().copied()),
             CharacterType::Block(block) => print_char_range(block.clone()),
-            // TODO: `char::MIN` and `char::MAX` are heading for stabilization. When they are
-            // stable we can replace these constants for those in std.
-            CharacterType::Anything => print_char_range('\0'..='\u{10ffff}'),
+            CharacterType::Anything => print_char_range(char::MIN..=char::MAX),
         }
         return Ok(());
     }


### PR DESCRIPTION
These constants on the `char` type was stabilized today with Rust 1.83