### PR TITLE
Add `--version` to CLI. Also print the about text in the `--help` output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ impl RuleDispatcher {
 }
 
 #[derive(Debug, clap::Parser)]
-#[command(arg_required_else_help = true, version)]
+#[command(arg_required_else_help = true, version, about)]
 struct Args {
     /// One or more files or directories to scan. Directories are scanned recursively.
     paths: Vec<PathBuf>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ impl RuleDispatcher {
 }
 
 #[derive(Debug, clap::Parser)]
-#[command(arg_required_else_help = true)]
+#[command(arg_required_else_help = true, version)]
 struct Args {
     /// One or more files or directories to scan. Directories are scanned recursively.
     paths: Vec<PathBuf>,


### PR DESCRIPTION
I realized that `unicop --version` gave an error. I think that's pretty uncommon and not very nice. The fix is very simple as you can see.

I also opted to include the about text in the help output. I just think this makes the tool nicer to use and explore. Some of the most rudimentary docs about the tool then come shipped with it. The about text is simply automatically taken from the `description` field in `Cargo.toml`