### PR TITLE
Make unicode blocks ordered

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,12 +141,12 @@ fn main() -> anyhow::Result<()> {
 
     if args.print_unicode_blocks {
         for (&name, range) in &unicode_blocks::UNICODE_BLOCKS {
-            print!("{name}");
             if args.verbose {
                 let range_start = char_to_unicode_notation(*range.start());
                 let range_end = char_to_unicode_notation(*range.end());
-                print!(": {range_start}..{range_end}");
+                print!("{range_start}..{range_end}: ");
             }
+            print!("{name}");
             println!();
         }
         return Ok(());

--- a/src/unicode_blocks.rs
+++ b/src/unicode_blocks.rs
@@ -328,7 +328,7 @@ pub const SUPPLEMENTARY_PRIVATE_USE_AREA_A: std::ops::RangeInclusive<char> = '\u
 pub const SUPPLEMENTARY_PRIVATE_USE_AREA_B: std::ops::RangeInclusive<char> = '\u{100000}'..='\u{10FFFF}';
 
 /// UNICODE_BLOCKS is a mapping from the pretty block name to the character range.
-pub static UNICODE_BLOCKS: phf::Map<&'static str, std::ops::RangeInclusive<char>> = phf::phf_map! {
+pub static UNICODE_BLOCKS: phf::OrderedMap<&'static str, std::ops::RangeInclusive<char>> = phf::phf_ordered_map! {
     "Basic Latin" => BASIC_LATIN,
     "Latin-1 Supplement" => LATIN_1_SUPPLEMENT,
     "Latin Extended-A" => LATIN_EXTENDED_A,


### PR DESCRIPTION
I realized that `--print-unicode-blocks` printed all unicode blocks in a seemingly random order. Because the phf maps are not ordered! But that was an easy fix, since the same crate provides an ordered map type as well!

I also realized the verbose printing, including the unicode range, was hard to read. since all the block names are of different length. So I changed it so the range is printed first. So instead of this:
```
Hangul Jamo: U+1100..U+11FF
Ethiopic: U+1200..U+137F
Ethiopic Supplement: U+1380..U+139F
Cherokee: U+13A0..U+13FF
```

We instead get this:
```
U+1100..U+11FF: Hangul Jamo
U+1200..U+137F: Ethiopic
U+1380..U+139F: Ethiopic Supplement
U+13A0..U+13FF: Cherokee
```

Which I think is way simpler to visually parse.