### PR TITLE
Print statistics about the scan before exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ $ unicop example-files/homoglyph.js example-files/invisible.js
    ·                                      ╰── HANGUL JUNGSEONG FILLER
  6 │    ];
    ╰────
+Scanned 486 unicode code points in 2 files, resulting in 3 rule violations
 
 ```
 


### PR DESCRIPTION
This helps the user validate if the tool ran at all and if it seemed to do anything useful at all. I did not like how `unicop .` on a *clean* code base just exited without even a whisper. It makes me scared whether or not the tool even failed to run or something.

These simple stats provide confidence that the tool *did something*. And it can be pretty nice to read IMO.