### PR TITLE
Exit with exit code 1 if a rule violation was found

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Where `[PATHS]...` is a list of files or directory to check.
 
 ```console
 $ unicop example-files/homoglyph.js example-files/invisible.js
+? failed
   × found disallowed character LATIN LETTER RETROFLEX CLICK in identifier
    ╭─[example-files/homoglyph.js:4:18]
  3 │ function isUserAdmin(user) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,9 @@ fn main() -> anyhow::Result<()> {
         num_files_scanned,
         global_scan_stats.num_rule_violations,
     );
+    if global_scan_stats.num_rule_violations > 0 {
+        std::process::exit(1);
+    }
     Ok(())
 }
 


### PR DESCRIPTION
This PR builds on top of #31 and must be merged after that PR.

Since the main use case for this tool is to run in CI and other automated pipelines, it must have some easy to use way of notifying upstream that it found an error! Without this, it becomes much harder to detect if the tool failed or not.

This check is not perfect. We might want to exit with a non-zero exit code in more cases. Such as on parsing errors etc. But I leave that as a future exercise, this is way better than before at least. I leave the rest for later also partially because I think we need to improve the error handling situation overall. Currently there is no way for the `main` function to know if a specific scan failed in a specific way.