### PR TITLE
Upgrade cargo audit to 0.21 via upgrading the action to 1.2.2

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions-rust-lang/audit@160ac8b6edd32f74656cabba9d1de3fc8339f676 # v1.2
+      - uses: actions-rust-lang/audit@5c5da92c0334eb692d0735bb94f086fd83e59572 # v1.2.2
         name: Audit Rust Dependencies
         with:
           denyWarnings: true


### PR DESCRIPTION
The CI has failed nightly for quite a while now. It notifies me every day :sweat_smile:

https://github.com/mullvad/unicop/actions/runs/12291117310/job/34299354694

 I'm hoping a simple upgrade of the CI action will resolve the problem.