### PR TITLE
Add C and C++ support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-cpp"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-go"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,6 +1038,7 @@ dependencies = [
  "serde",
  "toml",
  "tree-sitter",
+ "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-javascript",
  "tree-sitter-python",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-c"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afd2b1bf1585dc2ef6d69e87d01db8adb059006649dd5f96f31aa789ee6e9c71"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1048,7 @@ dependencies = [
  "serde",
  "toml",
  "tree-sitter",
+ "tree-sitter-c",
  "tree-sitter-cpp",
  "tree-sitter-go",
  "tree-sitter-javascript",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,8 @@ log = "0.4.22"
 env_logger = "0.11.5"
 owo-colors = { version = "4.1.0", features = ["supports-colors"] }
 
-# Grammars
+# Grammars (keep in alphabetical order)
+tree-sitter-cpp = "0.23.4"
 tree-sitter-go = "0.23.1"
 tree-sitter-javascript = "0.23.0"
 tree-sitter-python = "0.23.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ env_logger = "0.11.5"
 owo-colors = { version = "4.1.0", features = ["supports-colors"] }
 
 # Grammars (keep in alphabetical order)
+tree-sitter-c = "0.23.4"
 tree-sitter-cpp = "0.23.4"
 tree-sitter-go = "0.23.1"
 tree-sitter-javascript = "0.23.0"

--- a/example-files/README.md
+++ b/example-files/README.md
@@ -25,6 +25,22 @@ $ unicop example-files/
     ·                 ┬
     ·                 ╰── HANGUL JUNGSEONG FILLER
     ╰────
+  × found disallowed character RIGHT-TO-LEFT EMBEDDING in comment
+   ╭─[example-files/hello-trojan-source.c:3:19]
+ 2 │ int main() {
+ 3 │     // Will print ‫Hello World to the terminal
+   ·                   ┬
+   ·                   ╰── RIGHT-TO-LEFT EMBEDDING
+ 4 │    printf("Hello World! 👋");
+   ╰────
+  × found disallowed character RIGHT-TO-LEFT EMBEDDING in comment
+   ╭─[example-files/hello-trojan-source.cpp:4:19]
+ 3 │ int main() {
+ 4 │     // Will print ‫Hello World to the terminal
+   ·                   ┬
+   ·                   ╰── RIGHT-TO-LEFT EMBEDDING
+ 5 │     std::cout << "Hello World! 👋";
+   ╰────
   ⚠ example-files/homoglyph.go: parse error, results might be incorrect
   × found disallowed character LATIN LETTER RETROFLEX CLICK in identifier
    ╭─[example-files/homoglyph.go:7:16]
@@ -75,7 +91,7 @@ $ unicop example-files/
    ╰────
 Error while scanning example-files/not-utf-8-file.ts: Failed to read file (stream did not contain valid UTF-8)
 
-Scanned 1106 unicode code points in 6 files, resulting in 8 rule violations
+Scanned 1361 unicode code points in 8 files, resulting in 10 rule violations
 Failed to scan 1 file
 
 ```

--- a/example-files/hello-trojan-source.c
+++ b/example-files/hello-trojan-source.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+int main() {
+    // Will print ‫Hello World to the terminal
+   printf("Hello World! 👋");
+   return 0;
+}

--- a/example-files/hello-trojan-source.cpp
+++ b/example-files/hello-trojan-source.cpp
@@ -1,0 +1,7 @@
+#include <iostream>
+
+int main() {
+    // Will print ‫Hello World to the terminal
+    std::cout << "Hello World! 👋";
+    return 0;
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,8 @@ pub enum CodeType {
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum Language {
+    /// C++
+    CPlusPlus,
     Go,
     Javascript,
     Python,
@@ -82,6 +84,15 @@ pub enum Language {
     Swift,
     Typescript,
 }
+
+static CPP_CODE_TYPES: phf::Map<&'static str, CodeType> = phf::phf_map! {
+    "comment" => CodeType::Comment,
+
+    "char_literal" => CodeType::StringLiteral,
+    "raw_string_literal" => CodeType::StringLiteral,
+    "string_literal" => CodeType::StringLiteral,
+    "string_content" => CodeType::StringLiteral,
+};
 
 static GO_CODE_TYPES: phf::Map<&'static str, CodeType> = phf::phf_map! {
     "comment" => CodeType::Comment,
@@ -129,6 +140,7 @@ static TYPESCRIPT_CODE_TYPES: phf::Map<&'static str, CodeType> = phf::phf_map! {
 impl Language {
     pub fn lookup_code_type(&self, tree_sitter_code_type: &str) -> Option<CodeType> {
         match self {
+            Language::CPlusPlus => CPP_CODE_TYPES.get(tree_sitter_code_type).copied(),
             Language::Go => GO_CODE_TYPES.get(tree_sitter_code_type).copied(),
             Language::Javascript => JAVASCRIPT_CODE_TYPES.get(tree_sitter_code_type).copied(),
             Language::Python => PYTHON_CODE_TYPES.get(tree_sitter_code_type).copied(),
@@ -140,6 +152,7 @@ impl Language {
 
     pub fn grammar(&self) -> tree_sitter::Language {
         match self {
+            Language::CPlusPlus => tree_sitter_cpp::LANGUAGE.into(),
             Language::Go => tree_sitter_go::LANGUAGE.into(),
             Language::Javascript => tree_sitter_javascript::LANGUAGE.into(),
             Language::Python => tree_sitter_python::LANGUAGE.into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -74,7 +74,10 @@ pub enum CodeType {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
+// Keep variants in alphabetical order
 pub enum Language {
+    /// The C language
+    C,
     /// C++
     CPlusPlus,
     Go,
@@ -84,6 +87,14 @@ pub enum Language {
     Swift,
     Typescript,
 }
+
+static C_CODE_TYPES: phf::Map<&'static str, CodeType> = phf::phf_map! {
+    "comment" => CodeType::Comment,
+
+    "char_literal" => CodeType::StringLiteral,
+    "string_literal" => CodeType::StringLiteral,
+    "string_content" => CodeType::StringLiteral,
+};
 
 static CPP_CODE_TYPES: phf::Map<&'static str, CodeType> = phf::phf_map! {
     "comment" => CodeType::Comment,
@@ -140,6 +151,7 @@ static TYPESCRIPT_CODE_TYPES: phf::Map<&'static str, CodeType> = phf::phf_map! {
 impl Language {
     pub fn lookup_code_type(&self, tree_sitter_code_type: &str) -> Option<CodeType> {
         match self {
+            Language::C => C_CODE_TYPES.get(tree_sitter_code_type).copied(),
             Language::CPlusPlus => CPP_CODE_TYPES.get(tree_sitter_code_type).copied(),
             Language::Go => GO_CODE_TYPES.get(tree_sitter_code_type).copied(),
             Language::Javascript => JAVASCRIPT_CODE_TYPES.get(tree_sitter_code_type).copied(),
@@ -152,6 +164,7 @@ impl Language {
 
     pub fn grammar(&self) -> tree_sitter::Language {
         match self {
+            Language::C => tree_sitter_c::LANGUAGE.into(),
             Language::CPlusPlus => tree_sitter_cpp::LANGUAGE.into(),
             Language::Go => tree_sitter_go::LANGUAGE.into(),
             Language::Javascript => tree_sitter_javascript::LANGUAGE.into(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,6 +430,27 @@ fn get_default_config() -> Config {
         },
         language: HashMap::from([
             (
+                Language::CPlusPlus,
+                config::LanguageRules {
+                    // Various C++ compilers accept a myriad of file extensions.
+                    // This list does not aim to be exhaustive, but to cover the most common ones.
+                    paths: Some(vec![
+                        glob::Pattern::new("**/*.cpp").unwrap(),
+                        // The glob patterns are case-sensitive, and some compilers include uppercase
+                        // CPP in their list of recognized extensions.
+                        glob::Pattern::new("**/*.CPP").unwrap(),
+                        glob::Pattern::new("**/*.c++").unwrap(),
+                        // Yes, captial C is a thing in both GCC and clang for example.
+                        glob::Pattern::new("**/*.C").unwrap(),
+                        glob::Pattern::new("**/*.cc").unwrap(),
+                        glob::Pattern::new("**/*.cxx").unwrap(),
+                        // We'll also scan C++ header files.
+                        glob::Pattern::new("**/*.hpp").unwrap(),
+                    ]),
+                    rules: Default::default(),
+                },
+            ),
+            (
                 Language::Rust,
                 config::LanguageRules {
                     paths: Some(vec![glob::Pattern::new("**/*.rs").unwrap()]),

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,6 +430,17 @@ fn get_default_config() -> Config {
         },
         language: HashMap::from([
             (
+                Language::C,
+                config::LanguageRules {
+                    paths: Some(vec![
+                        glob::Pattern::new("**/*.c").unwrap(),
+                        // Both C and C++ commonly use .h. Here we'll scan it as C for now.
+                        glob::Pattern::new("**/*.h").unwrap(),
+                    ]),
+                    rules: Default::default(),
+                },
+            ),
+            (
                 Language::CPlusPlus,
                 config::LanguageRules {
                     // Various C++ compilers accept a myriad of file extensions.

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,11 +432,7 @@ fn get_default_config() -> Config {
             (
                 Language::C,
                 config::LanguageRules {
-                    paths: Some(vec![
-                        glob::Pattern::new("**/*.c").unwrap(),
-                        // Both C and C++ commonly use .h. Here we'll scan it as C for now.
-                        glob::Pattern::new("**/*.h").unwrap(),
-                    ]),
+                    paths: Some(vec![glob::Pattern::new("**/*.c").unwrap()]),
                     rules: Default::default(),
                 },
             ),
@@ -457,6 +453,8 @@ fn get_default_config() -> Config {
                         glob::Pattern::new("**/*.cxx").unwrap(),
                         // We'll also scan C++ header files.
                         glob::Pattern::new("**/*.hpp").unwrap(),
+                        // Both C and C++ commonly use .h. Here we'll scan it as C++ for now since it's a superset of C.
+                        glob::Pattern::new("**/*.h").unwrap(),
                     ]),
                     rules: Default::default(),
                 },


### PR DESCRIPTION
This PR adds support for C and C++.

The exact file extensions to trigger the C/C++ parsers on can be debated. I have not found any clear winning strategy here. One issue is that C++ can have a myriad of extensions (see this post for example: https://stackoverflow.com/a/3223792). Another, harder, question is what to parse `.h` files as? Both C and C++ commonly use this extension for their headers. Here I opted to parse it as C++, as that is _almost_ a superset of C. But this is problematic for multiple reasons:
* When scanning C header files, the tool will use the configured rulesets for C++, potentially rendering unwanted results for the user.
* C++ is not a proper superset of C, there might be parsing issues.
* ???