### PR TITLE
Make trycmd do snapshot testing of the entire example-files directory

### DIFF
--- a/example-files/README.md
+++ b/example-files/README.md
@@ -3,3 +3,79 @@
 This directory contains files to test-run unicop on.
 
 These files contain "bad" unicode in various ways.
+
+You can run `unicop` against this directory to see how it reports errors:
+
+```console
+$ unicop example-files/
+? failed
+  × found disallowed character LATIN LETTER RETROFLEX CLICK in identifier
+    ╭─[example-files/examples.ts:11:16]
+ 10 │ // Homoglyph
+ 11 │ if (environmentǃ=ENV_PROD) {}
+    ·                ┬
+    ·                ╰── LATIN LETTER RETROFLEX CLICK
+ 12 │ 
+    ╰────
+  × found disallowed character HANGUL JUNGSEONG FILLER in
+  │ shorthand_property_identifier_pattern
+    ╭─[example-files/examples.ts:14:17]
+ 13 │ // Invisible
+ 14 │ const { timeout,ᅠ} = req.query;
+    ·                 ┬
+    ·                 ╰── HANGUL JUNGSEONG FILLER
+    ╰────
+  ⚠ example-files/homoglyph.go: parse error, results might be incorrect
+  × found disallowed character LATIN LETTER RETROFLEX CLICK in identifier
+   ╭─[example-files/homoglyph.go:7:16]
+ 6 │     environment := "..."
+ 7 │     if environmentǃ= EnvProd {
+   ·                   ┬
+   ·                   ╰── LATIN LETTER RETROFLEX CLICK
+ 8 │         // bypass authZ checks in DEV
+   ╰────
+  × found disallowed character LATIN LETTER RETROFLEX CLICK in identifier
+   ╭─[example-files/homoglyph.js:4:18]
+ 3 │ function isUserAdmin(user) {
+ 4 │    if(environmentǃ=ENV_PROD){
+   ·                  ┬
+   ·                  ╰── LATIN LETTER RETROFLEX CLICK
+ 5 │        // bypass authZ checks in DEV
+   ╰────
+  × found disallowed character LATIN LETTER RETROFLEX CLICK in identifier
+   ╭─[example-files/homoglyph.py:1:12]
+ 1 │ environmentǃ="PROD"
+   ·            ┬
+   ·            ╰── LATIN LETTER RETROFLEX CLICK
+   ╰────
+  × found disallowed character LATIN LETTER RETROFLEX CLICK in
+  │ simple_identifier
+   ╭─[example-files/homoglyph.swift:1:12]
+ 1 │ environmentǃ="PROD"
+   ·            ┬
+   ·            ╰── LATIN LETTER RETROFLEX CLICK
+ 2 │ 
+   ╰────
+  × found disallowed character HANGUL JUNGSEONG FILLER in
+  │ shorthand_property_identifier_pattern
+   ╭─[example-files/invisible.js:2:20]
+ 1 │ app.get('/network_health', async (req, res) => {
+ 2 │    const { timeout,ᅠ} = req.query;
+   ·                    ┬
+   ·                    ╰── HANGUL JUNGSEONG FILLER
+ 3 │    const checkCommands = [
+   ╰────
+  × found disallowed character HANGUL JUNGSEONG FILLER in identifier
+   ╭─[example-files/invisible.js:5:38]
+ 4 │        'ping -c 1 google.com',
+ 5 │        'curl -s http://example.com/',ᅠ
+   ·                                      ┬
+   ·                                      ╰── HANGUL JUNGSEONG FILLER
+ 6 │    ];
+   ╰────
+Error while scanning example-files/not-utf-8-file.ts: Failed to read file (stream did not contain valid UTF-8)
+
+Scanned 1106 unicode code points in 6 files, resulting in 8 rule violations
+Failed to scan 1 file
+
+```

--- a/src/main.rs
+++ b/src/main.rs
@@ -177,7 +177,8 @@ fn main() -> anyhow::Result<()> {
         num_rule_violations: 0,
     };
     for path in args.paths {
-        for entry in walkdir::WalkDir::new(path) {
+        let dir_iterator = walkdir::WalkDir::new(path).sort_by_file_name();
+        for entry in dir_iterator {
             match entry {
                 Err(err) => eprintln!("{:}", err),
                 Ok(entry) if entry.file_type().is_file() => {

--- a/tests/trycmd.rs
+++ b/tests/trycmd.rs
@@ -1,4 +1,6 @@
 #[test]
 fn trycmd() {
-    trycmd::TestCases::new().case("README.md");
+    trycmd::TestCases::new()
+        .case("README.md")
+        .case("example-files/README.md");
 }


### PR DESCRIPTION
This adds more assurance that our output does not change unintentionally.

I get that we don't want so long output in the example in our main `README.md`. But I also want to utilize the fact that we have a lot of example files, to further assert we don't accidentally introduce a bug or output change.