### PR TITLE
Upgrade tree-sitter-swift to latest release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-swift"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65aeb41726119416567d0333ec17580ac4abfb96db1f67c4bd638c65f9992fe"
+checksum = "bdc72ea9c62a6d188c9f7d64109a9b14b09231852b87229c68c44e8738b9e6b9"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tree-sitter-javascript = "0.23.0"
 tree-sitter-kotlin-ng = "1.1.0"
 tree-sitter-python = "0.23.2"
 tree-sitter-rust = "0.23.0"
-tree-sitter-swift = "0.6.0"
+tree-sitter-swift = "0.7.0"
 tree-sitter-typescript = "0.23.0"
 
 [dev-dependencies]


### PR DESCRIPTION
Improves the parser a bit with support for new features. Also upgrades it to `tree-sitter 0.23`. Changelog here: https://github.com/alex-pinkus/tree-sitter-swift/releases/tag/0.7.0