### PR TITLE
Improve parse error reporting

### DIFF
--- a/example-files/README.md
+++ b/example-files/README.md
@@ -7,7 +7,7 @@ These files contain "bad" unicode in various ways.
 You can run `unicop` against this directory to see how it reports errors:
 
 ```console
-$ unicop example-files/
+$ unicop example-files/ -v
 ? failed
   × found disallowed character LATIN LETTER RETROFLEX CLICK in identifier
     ╭─[example-files/examples.ts:11:16]

--- a/example-files/README.md
+++ b/example-files/README.md
@@ -104,3 +104,15 @@ Scanned 1647 unicode code points in 10 files, resulting in 11 rule violations
 Failed to scan 1 file
 
 ```
+
+You can also try it in the more strict mode, where parsing issues result in a failed run:
+
+```console
+$ unicop example-files/parse-errors.rs --deny-parse-errors
+? failed
+  ⚠ example-files/parse-errors.rs: parse error, results might be incorrect
+
+Scanned 193 unicode code points in 1 files, resulting in 0 rule violations
+1 file had parse errors
+
+```

--- a/example-files/README.md
+++ b/example-files/README.md
@@ -97,8 +97,10 @@ $ unicop example-files/ -v
  6 │    ];
    ╰────
 Error while scanning example-files/not-utf-8-file.ts: Failed to read file (stream did not contain valid UTF-8)
+  ⚠ example-files/parse-errors.rs: parse error, results might be incorrect
 
-Scanned 1454 unicode code points in 9 files, resulting in 11 rule violations
+Scanned 1647 unicode code points in 10 files, resulting in 11 rule violations
+2 files had parse errors
 Failed to scan 1 file
 
 ```

--- a/example-files/parse-errors.rs
+++ b/example-files/parse-errors.rs
@@ -1,0 +1,8 @@
+//! Example file that the current Rust grammars cannot fully parse.
+//! Used to test the --deny-parse-errors flag.
+
+fn function_with_parse_errors() {
+    match 123 {
+        ..0 => (),
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,6 +134,18 @@ struct Args {
     /// Enable more verbose output.
     #[arg(short, long)]
     verbose: bool,
+
+    /// Exit with a non-zero exit code if any parse errors are encountered.
+    ///
+    /// A parse error means that the language grammar can't correctly determine the code type for
+    /// some character(s) in the source code. This results in evaluating those characters with the
+    /// default rules for the language, instead of the code type specific rules.
+    ///
+    /// Parse errors are allowed by default since they both generate a lot of false positives due
+    /// to incomplete grammars, and because they are usually not a security risk. This can only
+    /// be a security risk if the default rules are more permissive than the code type specific rules.
+    #[arg(long)]
+    deny_parse_errors: bool,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -176,6 +188,7 @@ fn main() -> anyhow::Result<()> {
     let mut global_scan_stats = ScanStats {
         num_unicode_code_points: 0,
         num_rule_violations: 0,
+        num_parse_errors: 0,
     };
     for path in args.paths {
         let dir_iterator = walkdir::WalkDir::new(path).sort_by_file_name();
@@ -185,7 +198,11 @@ fn main() -> anyhow::Result<()> {
                 Ok(entry) if entry.file_type().is_file() => {
                     let entry_path = entry.path();
                     dispatcher.user_config = get_user_config(entry_path)?;
-                    match check_file(&dispatcher, entry_path, args.verbose) {
+                    match check_file(
+                        &dispatcher,
+                        entry_path,
+                        args.verbose || args.deny_parse_errors,
+                    ) {
                         Ok(Some(scan_stats)) => {
                             log::debug!(
                                 "Scanned {} unicode code points in {}",
@@ -196,6 +213,7 @@ fn main() -> anyhow::Result<()> {
                             global_scan_stats.num_unicode_code_points +=
                                 scan_stats.num_unicode_code_points;
                             global_scan_stats.num_rule_violations += scan_stats.num_rule_violations;
+                            global_scan_stats.num_parse_errors += scan_stats.num_parse_errors;
                         }
                         Ok(None) => log::trace!("Skipped {}", entry_path.display()),
                         Err(e) => {
@@ -209,7 +227,9 @@ fn main() -> anyhow::Result<()> {
         }
     }
 
-    let found_issue = global_scan_stats.num_rule_violations > 0 || num_failed_files > 0;
+    let found_issue = global_scan_stats.num_rule_violations > 0
+        || num_failed_files > 0
+        || (global_scan_stats.num_parse_errors > 0 && args.deny_parse_errors);
 
     // If any errors have been reported, print an empty line. Visually separates
     // the below stats summary from the above error printing
@@ -225,6 +245,17 @@ fn main() -> anyhow::Result<()> {
         global_scan_stats.num_rule_violations,
     );
     print_with_style(&scan_stats_msg, summary_print_style);
+
+    // Print number of files that encountered a parse error, if there are any
+    if args.verbose || args.deny_parse_errors {
+        match global_scan_stats.num_parse_errors {
+            0 => (),
+            1 => print_with_style("1 file had parse errors", summary_print_style),
+            n @ 2.. => {
+                print_with_style(&format!("{n} files had parse errors"), summary_print_style)
+            }
+        }
+    }
 
     match num_failed_files {
         0 => (),
@@ -289,7 +320,7 @@ impl std::error::Error for ScanError {
 fn check_file(
     dispatcher: &RuleDispatcher,
     path: &Path,
-    verbose: bool,
+    print_parse_error: bool,
 ) -> Result<Option<ScanStats>, ScanError> {
     let Some(lang) = dispatcher.language(path) else {
         return Ok(None);
@@ -306,9 +337,11 @@ fn check_file(
     let mut scan_stats = ScanStats {
         num_unicode_code_points: 0,
         num_rule_violations: 0,
+        num_parse_errors: if tree.root_node().has_error() { 1 } else { 0 },
     };
 
-    if tree.root_node().has_error() && verbose {
+    // If the parser encountered a parse error, print a warning.
+    if tree.root_node().has_error() && print_parse_error {
         let mut labels = Vec::new();
         if log::log_enabled!(log::Level::Debug) {
             let query = tree_sitter::Query::new(&lang.grammar(), "(ERROR) @error").unwrap();
@@ -333,6 +366,7 @@ fn check_file(
         print!("{:?}", report);
     }
 
+    // Evaluate each code point in the source code for rule violations.
     for (off, ch) in src.char_indices() {
         scan_stats.num_unicode_code_points += 1;
         let node = tree
@@ -369,6 +403,10 @@ struct ScanStats {
     pub num_unicode_code_points: u64,
     /// Number of rule violations encountered during the scan.
     pub num_rule_violations: u64,
+    /// How many files that had parse errors.
+    // Would ideally be represented as a boolean when returned from `check_file` and an integer
+    // in the global stats. But to avoid two very similar structs for now, we'll just go with integer.
+    pub num_parse_errors: u64,
 }
 
 fn get_user_config(path: &Path) -> anyhow::Result<Option<Config>> {


### PR DESCRIPTION
The tree-sitter grammar is not perfect. Languages evolve and the grammar can't guarantee to have a 1:1 mapping of allowed syntax for every language. The reality is that `unicop` prints *a lot* of false positives when ran against real world code bases. Before this PR all such issues were printed as warnings. That resulted in the tool being very noisy even if there were likely no real risk involved.

This PR first aim to silence these warnings by default. Making them print only if the `--verbose` flag is present. Then the PR also introduce a more pedantic mode with `--deny-parse-errors`. When this flag is present, any parsing issue is treated as an error and the tool exits with a non-zero exit code. It's not likely that this flag is going to be very usable on decently sized real world projects, but it's nice to be able to be pedantic if the user wants to.

Open question: Can we actually guarantee that a parse error strictly falls back to evaluating the affected code under the default rules rather than the code type specific rules? This PR currently makes that assumption and says that as long as the default rules are at least as strict as the code specific rules, this cannot introduce a security issue. Is that actually true? Or can a parsing error result in a variable name being classified as a string literal or similar?