### PR TITLE
Enable stricter linting on the unicop code base

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,8 +6,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  # TODO: Do not allow dead_code once crate is out of early prototyping stage
-  RUSTFLAGS: --deny warnings --allow dead_code
+  RUSTFLAGS: --deny warnings
 
 jobs:
   build-and-test:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,28 @@ tree-sitter-typescript = "0.23.0"
 
 [dev-dependencies]
 trycmd = "0.15.5"
+
+
+[lints.rust]
+# Unless we have a really good reason to use unsafe code in this tool, we should stay away from it.
+unsafe_code = "forbid"
+
+# Security
+non_ascii_idents = "forbid"
+
+# Deny old style Rust
+rust_2018_idioms = { level = "deny", priority = -1 }
+macro_use_extern_crate = "deny"
+absolute_paths_not_starting_with_crate = "deny"
+
+# Easy to read style and opinionated best practices
+explicit_outlives_requirements = "warn"
+single_use_lifetimes = "warn"
+
+# General cleanliness and cleanup
+unused_macro_rules = "warn"
+unused_extern_crates = "deny"
+unused_lifetimes = "warn"
+
+[lints.clippy]
+unused_async = "deny"


### PR DESCRIPTION
The first commit is a forgotten remain from early PoC days. We should not allow dead code any longer.

Second commit is to add lots of strict lint rules. Copied mostly from the [`mullvadvpn-app`](https://github.com/mullvad/mullvadvpn-app/blob/ca045c68af8ed3655d2d3ade69672e963dca90f0/Cargo.toml#L58-L77) repo setup.