### PR TITLE
Upgrade crate to Rust 2024 edition

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ jobs:
         # TODO: Add and make Windows work in CI also
         os: [ubuntu-latest, macos-latest]
         # Keep MSRV in sync with rust-version in Cargo.toml
-        rust: [stable, beta, nightly, 1.83.0]
+        rust: [stable, beta, nightly, 1.85.0]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ authors = ["Mullvad VPN"]
 repository = "https://github.com/mullvad/unicop"
 license = "GPL-3.0"
 
-edition = "2021"
-rust-version = "1.83.0"
+edition = "2024"
+rust-version = "1.85.0"
 
 [dependencies]
 miette = { version = "7.2.0", features = ["fancy"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use clap::Parser;
-use miette::{miette, LabeledSpan, NamedSource, Severity};
+use miette::{LabeledSpan, NamedSource, Severity, miette};
 use tree_sitter::StreamingIterator;
 use unic_ucd_name::Name;
 
@@ -299,7 +299,7 @@ impl fmt::Display for ScanError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ScanError::*;
         match self {
-            ReadFile(ref e) => write!(f, "Failed to read file ({e})"),
+            ReadFile(e) => write!(f, "Failed to read file ({e})"),
         }
     }
 }


### PR DESCRIPTION
For no particular strong reason other than it being modern and nice and our code is compatible with it. I see no strong reason to maintain a lower MSRV than latest stable for this project.