### PR TITLE
Exclude files and directories not needed when publishing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ license = "GPL-3.0"
 edition = "2024"
 rust-version = "1.85.0"
 
+exclude = ["/example-files"]
+
 [dependencies]
 miette = { version = "7.2.0", features = ["fancy"] }
 tree-sitter = "0.25.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ license = "GPL-3.0"
 edition = "2024"
 rust-version = "1.85.0"
 
-exclude = ["/example-files"]
+exclude = ["/example-files", "/.github"]
 
 [dependencies]
 miette = { version = "7.2.0", features = ["fancy"] }


### PR DESCRIPTION
The defaults in cargo is to publish basically everything in the root. I don't think these are sane defaults, but it's OK most of the time. Here I want to avoid packaging and publishing a bunch of files that are intentionally containing "bad" unicode, so I explicitly exclude the `example-files` directory. While at it, we can exclude the github actions workflow stuff as well. I see no reason to have them published to crates.io