### PR TITLE
Remove early development relaxation of dead_code lint

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -23,6 +23,5 @@ jobs:
 
       - name: Clippy check
         env:
-          # TODO: Do not allow dead_code once crate is out of early prototyping stage
-          RUSTFLAGS: --deny warnings --allow dead_code
+          RUSTFLAGS: --deny warnings
         run: cargo clippy --locked --all-targets


### PR DESCRIPTION
I found this TODO. We should probably not allow `dead_code` any longer, as we are not in early prototyping stage :)